### PR TITLE
Address FWUG concerns

### DIFF
--- a/libnvme/Cargo.toml
+++ b/libnvme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libnvme"
-version = "0.1.1"
+version = "0.1.2"
 license = "MPL-2.0"
 edition = "2021"
 


### PR DESCRIPTION
Rather than add support for `nvme_ctrl_info_fwgran` we are following in `nvmeadm`s footsteps and splitting firmware blobs into 64k chunks and not padding out any remaining bytes with zeros.

Corresponding illumos commit [illumos#29afde7ed707ee1c13d8307aaf2bfa026d54d66d.](https://github.com/illumos/illumos-gate/commit/29afde7ed707ee1c13d8307aaf2bfa026d54d66d).
Fixes #7.

