### PR TITLE
Teach libnvme about nvme_log_req_clear_output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "libnvme"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "libnvme-sys",
  "nvme",

--- a/libnvme-sys/src/nvme.rs
+++ b/libnvme-sys/src/nvme.rs
@@ -341,6 +341,7 @@ extern "C" {
         buf: *mut c_void,
         buflen: usize,
     ) -> bool;
+    pub fn nvme_log_req_clear_output(req: *mut nvme_log_req_t) -> bool;
     pub fn nvme_log_disc_calc_size(
         disc: *const nvme_log_disc_t,
         act: *mut u64,

--- a/libnvme/Cargo.toml
+++ b/libnvme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libnvme"
-version = "0.1.2"
+version = "0.1.3"
 license = "MPL-2.0"
 edition = "2021"
 


### PR DESCRIPTION
[16774 nvme persistent event log support](https://github.com/illumos/illumos-gate/commit/1c02c6c85edfeb48df1fe18511a8779bf9d6c6ed#diff-88971ec3d8f9c1492de0a3c001c7f54d6f352057f254ecc76d3c39dc38471b6eR138) introduced the ability for libnvme to clear the log req buffer. We can now use this when determining the actual size of a log req output, which enables us to stop carrying around an extra vec of data.